### PR TITLE
Consider cross-platform issues in `sharp` npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,13 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "^0.33.0",
+        "@img/sharp-darwin-x64": "^0.33.0",
+        "@img/sharp-linux-arm": "^0.33.0",
+        "@img/sharp-linux-arm64": "^0.33.0",
+        "@img/sharp-linux-x64": "^0.33.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -29,5 +29,12 @@
     "ts-jest": "^29.1.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.3.3"
+  },
+  "optionalDependencies": {
+    "@img/sharp-linux-x64": "^0.33.0",
+    "@img/sharp-linux-arm": "^0.33.0",
+    "@img/sharp-linux-arm64": "^0.33.0",
+    "@img/sharp-darwin-x64": "^0.33.0",
+    "@img/sharp-darwin-arm64": "^0.33.0"
   }
 }


### PR DESCRIPTION
## About

`sharp` npm has complex cross-platform issues.
A wider range of platforms can be supported by specifying optionalDependencies in package.json so that it can work on multiple platforms.
Official Documentation: https://sharp.pixelplumbing.com/install#cross-platform

## Description

Presumably @smellman is developing on macOS, but I am developing on WSL2 Ubuntu on Windows 10.

In the latest main branch, in my environment, I get an error when I `npm install` and run `npm run test`.

## memo

気のせいだったかもしれないので自分のFork先のリポジトリでDraftのPull Requestにしておく。。